### PR TITLE
smallRandomMouse amended to WalkPath & WebWalk

### DIFF
--- a/osr/walker/walker.simba
+++ b/osr/walker/walker.simba
@@ -345,6 +345,7 @@ function TRSWalker.WalkPath(Path: TPointArray; WaitUntilDistance: Int32 = 0): Bo
 var
   PlayerPoint: TPoint;
   Index, Fails: Int32;
+  P: TPoint;
 begin
   Self.Enabled := True;
   Self.Path := BuildPath([Self.GetMyPos()] + Path);
@@ -376,7 +377,16 @@ begin
       if Self.WalkFinalStep(PlayerPoint, Self.Path[Index], WaitUntilDistance, SRL.Dice(3)) then
         Exit(True);
     end else
-      Self.WalkStep(PlayerPoint, Self.Path[Index], SRL.Dice(10));
+      begin
+        Self.WalkStep(PlayerPoint, Self.Path[Index], SRL.Dice(10));
+        if SRL.Dice(40) then
+      begin
+        repeat
+            P := SRL.RandomPoint(Mouse.Position(), 150);
+        until P.DistanceTo(Mouse.Position) > 50; // Make sure we move at least 50 pixels
+          ASyncMouse.Move(P);
+      end;
+        end;
   end;
 
   if Fails = 10 then
@@ -454,8 +464,17 @@ end;
 
 
 function TRSWalker.WebWalk(Destination: TPointArray; WaitUntilDistance: Int32 = 0; PathRandomness: Extended = 0): Boolean; overload;
+var
+  P: TPoint;
 begin
   Result := Self.WebWalk(Self.GetClosestTile(Destination), WaitUntilDistance, PathRandomness);
+    if SRL.Dice(40) then
+      begin
+        repeat
+            P := SRL.RandomPoint(Mouse.Position(), 150);
+        until P.DistanceTo(Mouse.Position) > 50; // Make sure we move at least 50 pixels
+          ASyncMouse.Move(P);
+      end;
 end;
 
 


### PR DESCRIPTION
I've amended a modified smallRandomMouse to both WalkPath and WebWalk:

When these functions are called, 40% chance when new flags are posted on the MM, the mouse will attempt to move distance (min. 50, max 150 pixels) away radially before continuing to plot next flag. 
-Uses ASyncMouse (separately threaded mouse-movement for minimal interference)