### PR TITLE
Added RC Ruins, Altars, and Portals; begin Rift exp

### DIFF
--- a/osr/waspobjects/rsobjects.simba
+++ b/osr/waspobjects/rsobjects.simba
@@ -54,6 +54,17 @@ type
     LunarBank: TRSObject;
     AstralAltar: TRSObject;
 
+  //Order of Tiles: Air, Mind, Water, Earth, Fire, Body, Cosmic, Chaos, Nature, Law
+  //Order of Array: 0     1     2       3     4     5     6       7     8       9
+    Ruins: TRSObject;
+    Altar: TRSObject;
+    Portal: TRSObject;
+
+  //Order of Tiles[Rift]: Air, Mind, Water, Earth, Fire, Body, Cosmic, Chaos, Nature, Law, Death, Blood, Soul
+  //Order of Array:       0     1     2       3     4     5     6         7     8       9    10    11      12
+  //Experimental
+    Rift: TRSObject;
+
     BurningFire: TRSObject; //any burning fire you want, just set it's coordinates or use with color only
 
 
@@ -355,6 +366,26 @@ begin
   AstralAltar.Finder.ColorClusters += [CTS2(6318191, 13, 0.39, 0.38),
                                        CTS2(9998494, 5, 1.07, 0.47), 40];
 
+  Ruins.SetupCommon;
+  Ruins.UpText := ['Mysterious'];
+  Ruins.Finder.ColorClusters += [CTS2(5721426, 16, 2.63, 0.35),
+                    CTS2(4607558, 9, 0.52, 0.19), 30];
+
+  Altar.SetupCommon;
+  Altar.UpText := ['Craft'];
+  Altar.Finder.Colors += CTS2(6383470, 14, 0.37, 0.30);
+  Altar.Finder.Colors += CTS2(2763823, 8, 0.75, 0.54);
+
+  Portal.SetupCommon;
+  Portal.UpText := ['Portal'];
+  Portal.Finder.Colors += CTS2(10405581, 15, 0.18, 1.80);//Goldish color found throughout
+  Portal.Finder.Colors += CTS2(14076102, 13, 0.29, 0.61);//Water
+  Portal.Finder.Colors += CTS2(3034817, 5, 0.60, 3.57);//Fire
+  Portal.Finder.Colors += CTS2(9933785, 10, 0.05, 2.28);//Body
+
+  Rift.SetupCommon;
+  Rift.UpText := ['Exit-through'];
+  Rift.Filter.Finder := False;
 
   BurningFire.SetupCommon;
   BurningFire.Filter.UpText := False;
@@ -677,6 +708,10 @@ begin
 
   LunarBank.SetupCommon(Walker, 7, [[4381, 1259]]);
   AstralAltar.SetupCommon(Walker, 4, 3, [[4616, 1484]]);
+
+  Altar.SetupCommon(Walker, 5, 3, [[9831, 182], [9599, 153], [9320, 173], [9086, 153], [8795, 166], [8548, 158], [7022, 184], [7539, 149], [8055, 154], [8311, 188]]);
+  Portal.SetupCommon(Walker, 3, 2, [[9819, 205], [9627, 209], [9363, 190], [9074, 203], [8752, 118], [8538, 185], [7023, 102],[8055, 182], [8312, 248]]);
+  Rift.SetupCommon(Walker, 1, 1, [[10138, 4899], [10125, 4912], [10152, 4872], [10077, 4901], [10069, 4882], [10106, 4917], [10066, 4853], [10128,  4838], [10092, 4837], [10145, 4847], [10149, 4855], [10062, 4866], [10148, 4887]]);
 
   BurningFire.SetupCommon(Walker, 1, []);
 


### PR DESCRIPTION
Runecrafting Ruins, Altars, and Portals have been added. Expanded for size differentials on all required objects.
-Can be called by Altar.Click, Ruins.Click, and Portal.Click. No need to specify which Rune location as it will automatically search by your location.

Begin experimentation with Abyss Rifts.
-Currently includes Tiles of all Rift locations for Runecrafting, see include for Array sequence to specify which Rift to exit via.