### PR TITLE
UpText now properly displayers Portal instead of RCPortal.

### DIFF
--- a/osr/waspobjects/rsobjects.simba
+++ b/osr/waspobjects/rsobjects.simba
@@ -144,7 +144,7 @@ begin
                                       CTS2(6252136, 18, 0.21, 0.08), 30];
 
   POHPortal.SetupCommon;
-  POHPortal.UpText := ['RCPortal'];
+  POHPortal.UpText := ['Portal'];
   POHPortal.Finder.Colors += CTS2(6316135, 8, 0.28, 0.12);
   POHPortal.Finder.Colors += CTS2(9379961, 30, 0.16, 1.76);
   POHPortal.Finder.ColorClusters += [CTS2(9379961, 30, 0.16, 1.76),
@@ -363,7 +363,7 @@ begin
   RCAltar.Finder.Colors += CTS2(2763823, 8, 0.75, 0.54);
 
   RCPortal.SetupCommon;
-  RCPortal.UpText := ['RCPortal'];
+  RCPortal.UpText := ['Portal'];
   RCPortal.Finder.Colors += CTS2(10405581, 15, 0.18, 1.80);//Goldish color found throughout
   RCPortal.Finder.Colors += CTS2(14076102, 13, 0.29, 0.61);//Water
   RCPortal.Finder.Colors += CTS2(3034817, 5, 0.60, 3.57);//Fire
@@ -622,7 +622,7 @@ begin
   Gravestone.SetupCommon(Walker, 4, []); //Tiles should be set on death!
 
 
-  POHPortal.SetupCommon(Walker, 7, //Rimmington RCPortal
+  POHPortal.SetupCommon(Walker, 7, //Rimmington Portal
     [[7198, 3544], [7198, 3548], [7198, 3552], [7198, 3556], [7198, 3560],
      [7202, 3544], [7202, 3548], [7202, 3552], [7202, 3556], [7202, 3560]]
   );


### PR DESCRIPTION
Prior update had included 'RCPortal' in UpText. Most likely mistake when Replace-All was executed.