### PR TITLE
More variety of POH Portals added

### DIFF
--- a/osr/waspobjects/rsobjects.simba
+++ b/osr/waspobjects/rsobjects.simba
@@ -622,10 +622,12 @@ begin
   Gravestone.SetupCommon(Walker, 4, []); //Tiles should be set on death!
 
 
-  POHPortal.SetupCommon(Walker, 7, //Rimmington Portal
-    [[7198, 3544], [7198, 3548], [7198, 3552], [7198, 3556], [7198, 3560],
-     [7202, 3544], [7202, 3548], [7202, 3552], [7202, 3556], [7202, 3560]]
-  );
+  //                          Rimmington,   Taverly,      Brimhaven
+  POHPortal.SetupCommon(Walker, 7, [[7198, 3552], [2351, 2376], [6414, 3733]], [1, 2, 0, 1]);//Vertical POH's
+  //                         Pollnivneach, Rellekka,      Yanille
+  POHPortal.SetupCommon(Walker, 7, [[8754, 4444], [6074, 1932], [5568, 4059]], [1, 0, 2, 2]); //Horizontal POH's
+  //                          Hosidius
+  POHPortal.SetupCommon(Walker, 7, [[2349, 2377]], [1, 2, 0, 1]);//Zeah
 
   AlKharidBank.SetupCommon(Walker, 7,
     [[8465, 3771], [8465, 3776], [8465, 3780], [8465, 3783], [8465, 3792]]);


### PR DESCRIPTION
Due to difference in POH Portals standing either horizontally or vertically in addition to separate Maps (Mainland and Zeah), the TileArray has been enumerated into 3 categories. -This causes issues in its current state when calling POHPortal if its location is not in the 1st TileArray. *Needs fixing*