### PR TITLE
fix(RSObjects): Prif bank to BankUnspecified and uptext

### DIFF
--- a/osr/walker/objects/rsobjects.simba
+++ b/osr/walker/objects/rsobjects.simba
@@ -159,7 +159,7 @@ begin
     with BankChestWood1 do
     begin
       Setup(4, [[2090, 2000], [5541, 2155], [1761, 2559], [1445, 2775], [7137, 3327], [8013, 5107]]);
-      Setup(['ank b', 'ches']);
+      Setup(['ank c', 'ches']);
       Finder.ColorClusters += [CTS2(1985634, 16, 0.05, 0.50), CTS2(5135991, 18, 0.38, 1.01), 30];
       Finder.ColorClusters += [CTS2(2902103, 15, 0.04, 0.40), CTS2(4281697, 17, 0.08, 0.11), 5];
     end;
@@ -167,7 +167,7 @@ begin
     with BankChestWood2 do
     begin
       Setup(4, [[405, 1491], [10022, 3986], [10022, 3990], [10022, 3994], [10022, 3998], [10022, 4002]]);
-      Setup(['ank b', 'ches']);
+      Setup(['ank c', 'ches']);
       Finder.ColorClusters += [CTS2(1985634, 16, 0.05, 0.50), CTS2(5135991, 18, 0.38, 1.01), 30];
       Finder.ColorClusters += [CTS2(2902103, 15, 0.04, 0.40), CTS2(4281697, 17, 0.08, 0.11), 5];
     end;

--- a/osr/walker/objects/rsobjects.simba
+++ b/osr/walker/objects/rsobjects.simba
@@ -19,7 +19,7 @@ type RSObjects = record(TSRLBaseRecord) class var
 
     BankChestUnspecified,
 
-    TzhaarBank, PrifddinasBank, WintertodtBank,
+    TzhaarBank, WintertodtBank,
     PiscariliusBank, LumbridgeCastleBank, LunarBank,
     
     DepositBoxRegular, DepositBoxWood, DepositBoxWintertodt,
@@ -116,7 +116,7 @@ begin
     with BankWood1 do
     begin
       Setup(7, [[1341, 2087], [1341, 2091], [1341, 2095], [7173, 2979], [7177, 2979], [7181, 2979], [7185, 2979], [7433, 3031], [7437, 3031], [7441, 3031], [7445, 3031], [7449, 3031]]);
-      Setup(['Bank ', 'booth']);
+      Setup(['ank b', 'booth']);
       Finder.Colors += CTS2(3099996, 17, 0.12, 0.59);
       Finder.Colors += CTS2(4086642, 5, 0.08, 0.55);
       Finder.ClusterDistance := 15;
@@ -127,7 +127,7 @@ begin
     with BankWood2 do
     begin
       Setup(7, [[2381, 2059], [2381, 2063], [2381, 2067], [6277, 2471], [6281, 2471], [6289, 2471], [6301, 2471], [6305, 2471], [6309, 2471]]);
-      Setup(['Bank ', 'booth']);
+      Setup(['ank b', 'booth']);
       Finder.Colors += CTS2(3099996, 17, 0.12, 0.59);
       Finder.Colors += CTS2(4086642, 5, 0.08, 0.55);
     end;
@@ -135,7 +135,7 @@ begin
     with BankWood2 do
     begin
       Setup(7, [[385, 1423], [389, 1423], [7981, 2651], [7985, 2651], [8137, 2671], [8137, 2679], [8137, 2687], [8137, 2695], [8137, 2703], [8397, 2771], [8401, 2771], [8405, 2771], [8409, 2771], [8413, 2771], [8417, 2771]]);
-      Setup(['Bank ', 'booth']);
+      Setup(['ank b', 'booth']);
       Finder.Colors += CTS2(998986, 12, 0.13, 2.87);
       Finder.Erode := 8;
     end;
@@ -143,22 +143,23 @@ begin
     with BankWoodStone2 do
     begin
       Setup(7, [[6761, 2275], [7777, 2475], [7785, 2475], [7773, 2483], [7773, 2491], [6621, 2679], [6629, 2679], [6633, 2679], [6637, 2679], [5733, 2759], [5733, 2763], [5733, 2771], [5733, 2775], [5853, 3123], [5865, 3123], [5869, 3123], [6017, 3303], [6017, 3315], [6017, 3327], [7757, 3467], [7757, 3475], [7757, 3479], [8465, 3771], [8465, 3775], [8465, 3779], [8465, 3783], [8465, 3791], [5849, 4071], [5849, 4079], [5849, 4083]]);
-      Setup(['Bank ', 'booth']);
+      Setup(['ank b', 'booth']);
       Finder.Colors += CTS2(2256265, 18, 0.05, 2.33);
     end;
 
     with BankUnspecified do
     begin
       Setup(7, [[1133, 1123], [1149, 1123], [1133, 1131], [1149, 1147], [1133, 1163], [1133, 1171], [1149, 1171], [4372, 1260], [4376, 1260], [4380, 1260], [2577, 1295], [2593, 1295], [2609, 1295], [2625, 1295], [1885, 1463], [1937, 1463], [1885, 1475], [1937, 1475], [1885, 1487], [1937, 1487], [1473, 1495], [1481, 1495], [1489, 1495], [1497, 1495], [1505, 1495], [1513, 1495], [1885, 1499], [1937, 1499], [1481, 1511], [1513, 1511], [1885, 1511], [1937, 1511], [9582, 1819], [9582, 1823], [9582, 1827], [3879, 2104], [3887, 2104], [3875, 2128], [3879, 2128], [3887, 2128], [4039, 2304], [4039, 2308], [4039, 2312], [9445, 2515], [9445, 2519], [9445, 2523], [9445, 2527], [9445, 2531], [9445, 2535], [10141, 2587], [10145, 2587], [10157, 2587], [5745, 2759], [5745, 2787], [9805, 2975], [9809, 2975], [9813, 2975], [9821, 2975], [7777, 3467], [7777, 3479], [7757, 3483], [7777, 3483], [9989, 3619], [9997, 3619], [10001, 3619], [7873, 3951], [7881, 3951], [6238, 4704], [6246, 4704], [6250, 4704], [6254, 4704], [9097, 4871], [9097, 4875], [9097, 4883], [9097, 4891], [10443, 5336]]);
-      Setup(['Bank ', 'booth']);
+      Setup(['ank b', 'booth']);
       Finder.ColorClusters += [CTS2(1985634, 16, 0.05, 0.50), CTS2(5135991, 18, 0.38, 1.01), 30];
       Finder.ColorClusters += [CTS2(2902103, 15, 0.04, 0.40), CTS2(4281697, 17, 0.08, 0.11), 5];
+      Finder.ColorClusters += [CTS2(11576730, 32, 0.27, 0.29), CTS2(5202024, 20, 0.14, 0.39), 50];
     end;
 
     with BankChestWood1 do
     begin
       Setup(4, [[2090, 2000], [5541, 2155], [1761, 2559], [1445, 2775], [7137, 3327], [8013, 5107]]);
-      Setup(['Bank ', 'ches']);
+      Setup(['ank b', 'ches']);
       Finder.ColorClusters += [CTS2(1985634, 16, 0.05, 0.50), CTS2(5135991, 18, 0.38, 1.01), 30];
       Finder.ColorClusters += [CTS2(2902103, 15, 0.04, 0.40), CTS2(4281697, 17, 0.08, 0.11), 5];
     end;
@@ -166,7 +167,7 @@ begin
     with BankChestWood2 do
     begin
       Setup(4, [[405, 1491], [10022, 3986], [10022, 3990], [10022, 3994], [10022, 3998], [10022, 4002]]);
-      Setup(['Bank ', 'ches']);
+      Setup(['ank b', 'ches']);
       Finder.ColorClusters += [CTS2(1985634, 16, 0.05, 0.50), CTS2(5135991, 18, 0.38, 1.01), 30];
       Finder.ColorClusters += [CTS2(2902103, 15, 0.04, 0.40), CTS2(4281697, 17, 0.08, 0.11), 5];
     end;
@@ -174,7 +175,7 @@ begin
     with BankChestWoodStone1 do
     begin
       Setup(4, [[6383, 627], [10098, 1671], [7189, 2979], [7453, 3031], [8921, 3367], [8917, 3371], [6037, 3795], [5169, 4115]]);
-      Setup(['Bank ', 'chest']);
+      Setup(['ank b', 'chest']);
       Finder.Colors += CTS2(998986, 12, 0.13, 2.87);
       Finder.Colors += CTS2(2832199, 14, 0.07, 0.10);
       Finder.Colors += CTS2(5855839, 20, 0.15, 0.09);
@@ -184,7 +185,7 @@ begin
     with BankChestUnspecified do
     begin
       Setup(4, [[4685, 412], [5081, 572], [1297, 951], [1373, 963], [1397, 1035], [1309, 1055], [9678, 1059], [689, 1159], [4379, 3121], [1283, 3874], [8629, 3967], [6254, 4708]]);
-      Setup(['Bank ', 'chest']);
+      Setup(['ank b', 'chest']);
       Finder.ColorClusters += [CTS2(1985634, 16, 0.05, 0.50), CTS2(5135991, 18, 0.38, 1.01), 30];
       Finder.ColorClusters += [CTS2(2902103, 15, 0.04, 0.40), CTS2(4281697, 17, 0.08, 0.11), 5];
     end;
@@ -199,19 +200,6 @@ begin
       Finder.Grow := 3;
     end;
 
-    with PrifddinasBank do
-    begin
-      Setup(7, [[3879, 2104], [3886, 2104], [3886, 2128], [3879, 2128], [3875, 2128], [4037, 2302], [4037, 2307], [4037, 2311]]);
-      Setup(['Bank ', 'booth']);
-      Finder.ColorClusters += [CTS2(11576730, 32, 0.27, 0.29), CTS2(5202024, 20, 0.14, 0.39), 50];
-      Finder.ClusterDistance := 3;
-      Finder.Erode := 5;
-      Finder.MaxLongSide := 80;
-      Finder.MinLongSide := 10;
-      Finder.MaxShortSide := 40;
-      Finder.MinShortSide := 3;
-    end;
-
     with LumbridgeCastleBank do
     begin
       Setup(7, [[10444, 5338], [10448, 5338]]);
@@ -222,14 +210,14 @@ begin
     with PiscariliusBank do
     begin
       Setup(6, [[2571, 1295], [2587, 1295], [2605, 1295], [2621, 1295]]);
-      Setup(['Bank ', 'booth']);
+      Setup(['ank b', 'booth']);
       Finder.Colors += CTS2(3824230, 15, 0.09, 0.37);
     end;
 
     with LunarBank do
     begin
       Setup(7, [[4372, 1260], [4376, 1260], [4380, 1260]]);
-      Setup(['Bank ', 'booth']);
+      Setup(['ank b', 'booth']);
       Finder.Colors += CTS2(3824749, 15, 0.06, 1.00);
     end;
 
@@ -1052,7 +1040,6 @@ begin
 
     @RSObjects.LunarBank,
     @RSObjects.TzhaarBank,
-    @RSObjects.PrifddinasBank,
     @RSObjects.WintertodtBank,
     @RSObjects.PiscariliusBank,
     @RSObjects.LumbridgeCastleBank,

--- a/osr/walker/objects/rsobjects.simba
+++ b/osr/walker/objects/rsobjects.simba
@@ -175,7 +175,7 @@ begin
     with BankChestWoodStone1 do
     begin
       Setup(4, [[6383, 627], [10098, 1671], [7189, 2979], [7453, 3031], [8921, 3367], [8917, 3371], [6037, 3795], [5169, 4115]]);
-      Setup(['ank b', 'chest']);
+      Setup(['ank c', 'chest']);
       Finder.Colors += CTS2(998986, 12, 0.13, 2.87);
       Finder.Colors += CTS2(2832199, 14, 0.07, 0.10);
       Finder.Colors += CTS2(5855839, 20, 0.15, 0.09);
@@ -185,7 +185,7 @@ begin
     with BankChestUnspecified do
     begin
       Setup(4, [[4685, 412], [5081, 572], [1297, 951], [1373, 963], [1397, 1035], [1309, 1055], [9678, 1059], [689, 1159], [4379, 3121], [1283, 3874], [8629, 3967], [6254, 4708]]);
-      Setup(['ank b', 'chest']);
+      Setup(['ank c', 'chest']);
       Finder.ColorClusters += [CTS2(1985634, 16, 0.05, 0.50), CTS2(5135991, 18, 0.38, 1.01), 30];
       Finder.ColorClusters += [CTS2(2902103, 15, 0.04, 0.40), CTS2(4281697, 17, 0.08, 0.11), 5];
     end;


### PR DESCRIPTION
Change uptext to stop it opening bank deposit boxes
![image](https://user-images.githubusercontent.com/54473694/229467384-01f36955-ce77-4854-b2bf-3052c8defbba.png)
