### PR TITLE
fix(rsnpcs.simba): MasterFarmer uptext

### DIFF
--- a/osr/walker/objects/rsnpcs.simba
+++ b/osr/walker/objects/rsnpcs.simba
@@ -122,7 +122,7 @@ begin
     with MasterFarmer do
     begin
       Setup(15, 6, [[7717, 3447]]);
-      Setup(['Master', 'Farmer']);
+      Setup(['Master F', 'Farmer']);
       Finder.Colors += CTS2(5139816, 15, 0.07, 0.09);
       Finder.ColorClusters += [CTS2(2317677, 9, 0.09, 2.50), CTS2(5139816, 15, 0.07, 0.09), 15];
     end;


### PR DESCRIPTION
with previous uptext it attempts to pickpocket Martin who can get locked in the cow pen. When this happens it continues to attempt pickpockets until failsafe