### PR TITLE
Fix withdraw teleport; fix middle screen interface jewellery

### DIFF
--- a/osr/handlers/teleports/transport.simba
+++ b/osr/handlers/teleports/transport.simba
@@ -229,16 +229,14 @@ begin
     findInterfaceAttempts += 1;
     // there are like 12 clusters, so just check if there are more than 8 for false positives
   until (clusteredText.Len() > 8) or (findInterfaceAttempts > 4);
-
   for textBox in clusteredText.ToTBA() do
   begin
+    textBox := textBox.Expand(5);
     OCR.LocateText(textBox, teleportLocation.destination, RS_FONT_PLAIN_12, TOCRColorFilter.Create([textColor]), foundTextBox);
     if foundTextBox.Area > 1 then
       begin
         Mouse.Move(foundTextBox.Center());
         Self.DebugLn(MainScreen.GetUpText());
-        //if MainScreen.IsUpText('Continue') then
-        //begin
         Mouse.Click(MOUSE_LEFT);
         Exit(True);
         //end;
@@ -336,7 +334,7 @@ begin
       for chargedJewellery in chargedVariants do
       begin
         Self.DebugLn('Withdrawing', chargedJewellery);
-        bankItem.Setup(chargedJewellery);
+        bankItem := bankItem.Setup(chargedJewellery, 1, False);
         if Bank.WithdrawItem(bankItem, False) then
           Exit(True);
         //The following shouldn't be required. The lines above already kinda do this.


### PR DESCRIPTION
OCR textbox wasn't large enough for the middle of the screen jewellery teleports (like skills necklace)

Seems like TRSBankItem changed from how it was being was used here so updated 