### PR TITLE
feat(combathandler): add dragon thrownaxe to spec weapons

### DIFF
--- a/osr/handlers/combathandler.simba
+++ b/osr/handlers/combathandler.simba
@@ -45,7 +45,8 @@ const
     'Abyssal dagger (p++)', 'Dragon dagger', 'Dragon dagger(p++)',
     'Dragon sword', 'Dragon longsword', 'Dinh''s bulwark', 'Abyssal tentacle',
     'Saradomin godsword', 'Granite hammer', 'Toxic blowpipe', 'Magic shortbow',
-    'Magic shortbow (i)', 'Armadyl crossbow', 'Dragon crossbow', 'Null'
+    'Magic shortbow (i)', 'Armadyl crossbow', 'Dragon crossbow', 'Dragon thrownaxe',
+    'Null'
   ];
 
   BRACELETS: TRSItemArray = [


### PR DESCRIPTION
Adding `Dragon thrownaxe` to list of spec weapons in combat handler