### PR TITLE
Fix: combathandler.simba open inventory for bracelet

### DIFF
--- a/osr/handlers/combathandler.simba
+++ b/osr/handlers/combathandler.simba
@@ -439,7 +439,7 @@ begin
   if Self.Bracelet = 'Null' then
     Exit;
 
-  Result := Inventory.ClickItem(Self.Bracelet);
+  Result := Inventory.Open and Inventory.ClickItem(Self.Bracelet);
 
   if Result then
   begin

--- a/osr/handlers/combathandler.simba
+++ b/osr/handlers/combathandler.simba
@@ -439,7 +439,7 @@ begin
   if Self.Bracelet = 'Null' then
     Exit;
 
-  Result := Inventory.Open and Inventory.ClickItem(Self.Bracelet);
+  Result := Inventory.Open() and Inventory.ClickItem(Self.Bracelet);
 
   if Result then
   begin


### PR DESCRIPTION
Inventory.ClickItem(Self.Bracelet); doesn't open inventory so it fails to equip bracelet as equipment tab is open from checking it hasn't crumbled