### PR TITLE
fix: Inventory.CountEmptySlots; workaround

### DIFF
--- a/osr/handlers/combathandler.simba
+++ b/osr/handlers/combathandler.simba
@@ -484,7 +484,7 @@ begin
 
   Result := (Minimap.GetSpecLevel() >= Self.WeaponSpec) and
             ((Self.SpecWeapon = Self.Weapon) or Inventory.ContainsItem(Self.Weapon) or
-            (Inventory.ContainsItem(Self.SpecWeapon) and Inventory.HasSpace(1)));
+            (Inventory.ContainsItem(Self.SpecWeapon) and ((28-length(Inventory.GetUsedSlots)) > 1)));
   Self.DoingSpec := Result;
 end;
 


### PR DESCRIPTION
See https://discord.com/channels/795071177475227709/1099786910253203638/1155184274648076368 Inventory.CountEmptySlots; is unreliable