### PR TITLE
Improved Chompy color

### DIFF
--- a/osr/walker/objects/rsmonsters.simba
+++ b/osr/walker/objects/rsmonsters.simba
@@ -180,7 +180,8 @@ begin
   begin
     Setup(55, 4, [[4977, 4255]]);
     Setup('Chompy bird');
-    Finder.Colors += CTS2(9550787, 19, 0.15, 0.74);
+    Finder.Colors += CTS2(8557684, 13, 0.06, 0.32);
+    Finder.Colors += CTS2(10603982, 11, 0.04, 0.58);
   end;
 
   with Self.MountainTroll do


### PR DESCRIPTION
The old Chompy color also shared some colors with the Nearby ogres bow, causing mouse overs.
CTS2(8557684, 13, 0.06, 0.32) - is the Chompy Tail
CTS2(10603982, 11, 0.04, 0.58) - Is the Chompy body

Ran for around 1 hour and was quite an improvement over the old color.