### PR TITLE
Correction of Amethyst uptext

### DIFF
--- a/osr/walker/objects/rsobjects.simba
+++ b/osr/walker/objects/rsobjects.simba
@@ -739,7 +739,7 @@ begin
      [6438, 687], [6450, 687], [6438, 682], [6451, 682], [6446, 675],
      [6446, 671]
     ]);
-    SetupUpText(['ine Roc']);
+    SetupUpText(['ine Amethy']);
     Finder.Colors += CTS2(7035284, 24, 0.20, 0.47);
     Finder.MinShortSide := 20;
   end;


### PR DESCRIPTION
Update Amethyst uptext, its not a rock rather a crystal with it's own specific uptext.

As per wiki, amethyst is only found in the mining guild:
https://oldschool.runescape.wiki/w/Amethyst_crystals

If we look at the uptext:
![Crystals](https://github.com/Torwent/WaspLib/assets/142507021/02746a5c-72e0-4929-be7c-5aca479dbc11)
