### PR TITLE
Extended Rune Fountain map

### DIFF
--- a/rsregions.simba
+++ b/rsregions.simba
@@ -1,0 +1,330 @@
+{$DEFINE WL_RSREGIONS_INCLUDED}
+{$IFNDEF WL_UTILS}
+  {$I WaspLib/utils.simba}
+{$ENDIF}
+
+type RSRegions = record(TSRLBaseRecord) class var
+    ABYSS:                      TBox;
+    ALTARS:                     TBox;
+    AL_KHARID:                  TBox;
+    ARDOUGNE:                   TBox;
+    ASGARNIAN_ICE_DUNGEON:      TBox;
+    BARBARIAN_AGILITY_COURSE:   TBox;
+    BARBARIAN_VILLAGE:          TBox;
+    BLAST_FURNACE:              TBox;
+    BRIMHAVEN_DUNGEON:          TBox;
+    CASTLE_WARS:                TBox;
+    CATACOMBS_OF_KOUREND:       TBox;
+    CATHERBY:                   TBox;
+    CHASM_OF_FIRE:              TBox;
+    CORSAIR_COVE:               TBox;
+    CORSAIR_COVE_DUNGEON:       TBox;
+    CRAFTING_GUILD:             TBox;
+    CRAFTING_GUILD_UPSTAIRS:    TBox;
+    DRAYNOR_VILLAGE:            TBox;
+    EDGEVILLE:                  TBox;
+    FALADOR:                    TBox;
+    FREMMENNIK_SLAYER_CAVE:     TBox;
+    GIANTS_DEN:                 TBox;
+    GIANTS_FOUNDRY:             TBox;
+    GRAND_EXCHANGE:             TBox;
+    GUARDIANS_OF_THE_RIFT:      TBox;
+    RUINS_OF_UNKAH:             TBox;
+    SHILO_VILLAGE:              TBox;
+    FOSSIL_ISLAND:              TBox;
+    PEST_CONTROL_ISLAND:        TBox;
+    PEST_CONTROL_OUTPOST:       TBox;
+    CRANDOR:                    TBox;
+    ENTRANA:                    TBox;
+    HESPORI:                    TBox;
+    HOSIDIUS_FRUIT_STALL_HOUSE: TBox;
+    HOSIDIUS_KITCHEN:           TBox;
+    IORWERTH_DUNGEON:           TBox;
+    KALPHITE_CAVE:              TBox;
+    KALPHITE_LAIR:              TBox;
+    KARUULM_SLAYER_DUNGEON:     TBox;
+    KBD_AND_NMZ:                TBox;
+    KOUREND_RUNECRAFTING:       TBox;
+    KRAKEN_COVE:                TBox;
+    LUMBRIDGE:                  TBox;
+    LUMBRIDGE_CELLAR:           TBox;
+    LUMBRIDGE_MID_FLOOR:        TBox;
+    LUMBRIDGE_ROOF:             TBox;
+    LUNAR_ISLE:                 TBox;
+    MINING_GUILD:               TBox;
+    MOS_LEHARMLESS_CAVE:        TBox;
+    MOTHERLOADE_MINE:           TBox;
+    MOURNER_TUNNELS:            TBox;
+    MUSA_POINT:                 TBox;
+    MYTHS_GUILD_MID_FLOOR:      TBox;
+    OTTOS_GROTTO:               TBox;
+    PISCARILIUS:                TBox;
+    PISCATORIS:                 TBox;
+    PRIFDDINAS:                 TBox;
+    RIMMINGTON:                 TBox;
+    ROGUES_DEN:                 TBox;
+    SEERS_VILLAGE:              TBox;
+    SLAYER_TOWER_FLOORS:        TBox;
+    SLAYER_TOWER_GROUNDFLOOR:   TBox;
+    SMOKE_DEVIL_DUNGEON:        TBox;
+    SMOKE_DUNGEON:              TBox;
+    STRONGHOLD_SLAYER_CAVE:     TBox;
+    TITHE_FARM:                 TBox;
+    MOR_UL_REK:                 TBox;
+    VARROCK:                    TBox;
+    VARROCK_EAST:               TBox;
+    VARROCK_WEST:               TBox;
+    WINTERTODT:                 TBox;
+    WOODCUTTING_GUILD:          TBox;
+    YANILLE:                    TBox;
+    ZULANDRA:                   TBox;
+    POH:                        TBox;
+    TEMPOROSS_COVE:             TBox;
+    ZANARIS:                    TBox;
+    VARROCK_SEWERS:             TBox;
+    FOSSIL_ISLAND_UNDERWATER:   TBox;
+    KELDAGRIM:                  TBox;
+    PORT_KHAZARD:               TBox;
+    APE_ATOLL:                  TBox;
+    MISCELLANIA:                TBox;
+    BANDIT_CAMP_QUARRY:         TBox;
+    TUTORIAL_ISLAND:            TBox;
+    DEATH_PLATEAU:              TBox;
+    CLAN_HALL:                  TBox;
+    REDWOOD:                    TBox;
+    GOD_WARS_DUNGEON:           TBox;
+    DARKMEYER:                  TBox;
+    GIANTS_PLATEAU:             TBox;
+    SOPHANEM_BANK:              TBox;
+    GEM_ROCKS_MINE:             TBox;
+    ISLE_OF_SOULS:              TBox;
+    TAVERLY_DUNGEON:            TBox;
+    PYRAMID_PLUNDER:            TBox;
+    SOPHANEM:                   TBox;
+    NARDAH:                     TBox;
+    PYRAMID_PLUNDER_ENTRANCE:   TBox;
+    JORMUNGANDS_PRISON:         TBox;
+    RELLEKKA:                   TBox;
+    UNGAEL:                     TBox;
+    EVIL_CHICKEN_LAIR:          TBox;
+    FEROX_ENCLAVE:              TBox;
+    FOUNTAIN_OF_RUNE:           TBox;
+  end;
+
+begin
+  RSRegions.ABYSS                      := [9670, 4424, 10559, 5400];
+  RSRegions.ALTARS                     := [6937, 0, 10559, 376];
+  RSRegions.AL_KHARID                  := [8356, 3096, 9171, 4090];
+  RSRegions.ARDOUGNE                   := [5608, 3032, 6184, 3476];
+  RSRegions.ASGARNIAN_ICE_DUNGEON      := [5374, 1144, 6000, 1600];
+  RSRegions.BARBARIAN_AGILITY_COURSE   := [5361, 2021, 5718, 2388];
+  RSRegions.BARBARIAN_VILLAGE          := [7580, 2516, 8100, 3050];
+  RSRegions.BLAST_FURNACE              := [10308, 1406, 10559, 1642];
+  RSRegions.BRIMHAVEN_DUNGEON          := [1272, 4050, 1930, 4960];
+  RSRegions.CASTLE_WARS                := [4628, 3838, 5312, 4420];
+  RSRegions.CATACOMBS_OF_KOUREND       := [0, 2721, 966, 3409];
+  RSRegions.CATHERBY                   := [6495, 2463, 6910, 2850];
+  RSRegions.CHASM_OF_FIRE              := [0, 0, 397, 906];
+  RSRegions.CORSAIR_COVE               := [5077, 4605, 5827, 5355];
+  RSRegions.CORSAIR_COVE_DUNGEON       := [9138, 5423, 9596, 5828];
+  RSRegions.CRAFTING_GUILD             := [6990, 3206, 7261, 3465];
+  RSRegions.CRAFTING_GUILD_UPSTAIRS    := [10298, 5442, 10484, 5632];
+  RSRegions.DRAYNOR_VILLAGE            := [7596, 3267, 7976, 3660];
+  RSRegions.EDGEVILLE                  := [7500, 2263, 8058, 2960];
+  RSRegions.FALADOR                    := [7051, 2796, 7750, 3300];
+  RSRegions.FREMMENNIK_SLAYER_CAVE     := [2348, 2903, 3002, 3433];
+  RSRegions.GIANTS_DEN                 := [2560, 3229, 3000, 3650];
+  RSRegions.GIANTS_FOUNDRY             := [4231, 3009, 4473, 3262];
+  RSRegions.GRAND_EXCHANGE             := [7780, 2300, 8400, 2950];
+  RSRegions.GUARDIANS_OF_THE_RIFT      := [7484, 5232, 7878, 5640];
+  RSRegions.RUINS_OF_UNKAH             := [7827, 4852, 8303, 5328];
+  RSRegions.SHILO_VILLAGE              := [6560, 4318, 7158, 4714];
+  RSRegions.FOSSIL_ISLAND              := [8801, 592, 9867, 1578];
+  RSRegions.PEST_CONTROL_ISLAND        := [5550, 5441, 5956, 5828];
+  RSRegions.PEST_CONTROL_OUTPOST       := [6022, 4504, 6399, 4851];
+  RSRegions.CRANDOR                    := [6520, 3139, 6987, 3617];
+  RSRegions.ENTRANA                    := [6520, 2817, 6988, 3206];
+  RSRegions.HESPORI                    := [412, 3702, 657, 3946];
+  RSRegions.HOSIDIUS_FRUIT_STALL_HOUSE := [2467, 1907, 2713, 2143];
+  RSRegions.HOSIDIUS_KITCHEN           := [1988, 1873, 2251, 2118];
+  RSRegions.IORWERTH_DUNGEON           := [3005, 2511, 3614, 3174];
+  RSRegions.KALPHITE_CAVE              := [573, 3356, 1044, 3800];
+  RSRegions.KALPHITE_LAIR              := [877, 4035, 1308, 4437];
+  RSRegions.KARUULM_SLAYER_DUNGEON     := [313, 0, 1432, 814];
+  RSRegions.KBD_AND_NMZ                := [5270, 264, 5623, 600];
+  RSRegions.KOUREND_RUNECRAFTING       := [1860, 737, 2818, 1259];
+  RSRegions.KRAKEN_COVE                := [10147, 1006, 10559, 1414];
+  RSRegions.LUMBRIDGE                  := [7850, 2950, 8700, 4000];
+  RSRegions.LUMBRIDGE_CELLAR           := [9839, 5269, 9938, 5472];
+  RSRegions.LUMBRIDGE_MID_FLOOR        := [9626, 5240, 9838, 5498];
+  RSRegions.LUMBRIDGE_ROOF             := [10346, 5218, 10546, 5475];
+  RSRegions.LUNAR_ISLE                 := [4127, 1027, 4747, 1650];
+  RSRegions.MINING_GUILD               := [6243, 384, 6699, 800];
+  RSRegions.MOS_LEHARMLESS_CAVE        := [0, 3332, 652, 4000];
+  RSRegions.MOTHERLOADE_MINE           := [7423, 4735, 7827, 5133];
+  RSRegions.MOURNER_TUNNELS            := [7090, 5135, 7500, 5550];
+  RSRegions.MUSA_POINT                 := [6655, 3565, 7300, 3950];
+  RSRegions.MYTHS_GUILD_MID_FLOOR      := [10321, 5604, 10559, 5828];
+  RSRegions.OTTOS_GROTTO               := [5293, 2256, 5610, 2631];
+  RSRegions.PISCARILIUS                := [2444, 1122, 2950, 1500];
+  RSRegions.PISCATORIS                 := [4391, 1853, 5021, 2422];
+  RSRegions.PRIFDDINAS                 := [3590, 1897, 4238, 2546];
+  RSRegions.RIMMINGTON                 := [6988, 3362, 7386, 3710];
+  RSRegions.ROGUES_DEN                 := [10262, 799, 10557, 1079];
+  RSRegions.SEERS_VILLAGE              := [6050, 2360, 6536, 2760];
+  RSRegions.SLAYER_TOWER_FLOORS        := [4702, 0, 5604, 357];
+  RSRegions.SLAYER_TOWER_GROUNDFLOOR   := [8931, 2044, 9285, 2402];
+  RSRegions.SMOKE_DEVIL_DUNGEON        := [5091, 5231, 5566, 5605];
+  RSRegions.SMOKE_DUNGEON              := [212, 3352, 1100, 4600];
+  RSRegions.STRONGHOLD_SLAYER_CAVE     := [3066, 5085, 3700, 5650];
+  RSRegions.TITHE_FARM                 := [2484, 2303, 2851, 2623];
+  RSRegions.MOR_UL_REK                 := [4349, 332, 5201, 1000];
+  RSRegions.VARROCK                    := [7527, 2261, 8710, 3200];
+  RSRegions.VARROCK_EAST               := [8235, 2362, 8723, 3119];
+  RSRegions.VARROCK_WEST               := [7780, 2300, 8400, 3116];
+  RSRegions.WINTERTODT                 := [1750, 270, 2080, 830];
+  RSRegions.WOODCUTTING_GUILD          := [1564, 2293, 2110, 2650];
+  RSRegions.YANILLE                    := [5509, 3879, 5955, 4200];
+  RSRegions.ZULANDRA                   := [3960, 4030, 4500, 4400];
+  RSRegions.POH                        := [1749, 0, 2009, 259];
+  RSRegions.TEMPOROSS_COVE             := [7345, 4343, 7744, 4736];
+  RSRegions.ZANARIS                    := [9715, 3830, 10559, 4472];
+  RSRegions.VARROCK_SEWERS             := [5407, 770, 6052, 1169];
+  RSRegions.FOSSIL_ISLAND_UNDERWATER   := [1129, 5407, 1769, 5824];
+  RSRegions.KELDAGRIM                  := [2381, 5122, 3028, 5764];
+  RSRegions.PORT_KHAZARD               := [5876, 3671, 6179, 3924];
+  RSRegions.APE_ATOLL                  := [5827, 4851, 6455, 5486];
+  RSRegions.MISCELLANIA                := [6400, 4998, 7076, 5487];
+  RSRegions.BANDIT_CAMP_QUARRY         := [7827, 4639, 8303, 5002];
+  RSRegions.TUTORIAL_ISLAND            := [7516, 3817, 8132, 4499];
+  RSRegions.DEATH_PLATEAU              := [6667, 1950, 6994, 2237];
+  RSRegions.CLAN_HALL                  := [5935, 5508, 6254, 5828];
+  RSRegions.REDWOOD                    := [938, 2851, 1127, 3075];
+  RSRegions.GOD_WARS_DUNGEON           := [1382, 3297, 2604, 3972];
+  RSRegions.DARKMEYER                  := [9657, 2791, 10156, 3196];
+  RSRegions.GIANTS_PLATEAU             := [8710, 3646, 9193, 4011];
+  RSRegions.SOPHANEM_BANK              := [6095, 617, 6306, 843];
+  RSRegions.GEM_ROCKS_MINE             := [3912, 627, 4238, 889];
+  RSRegions.ISLE_OF_SOULS              := [4020, 4332, 5202, 5426];
+  RSRegions.TAVERLY_DUNGEON            := [5522, 0, 6301, 895];
+  RSRegions.PYRAMID_PLUNDER            := [1353, 0, 1751, 397];
+  RSRegions.SOPHANEM                   := [8397, 5131, 8762, 5536];
+  RSRegions.NARDAH                     := [8908, 4601, 9288, 4987];
+  RSRegions.PYRAMID_PLUNDER_ENTRANCE   := [9299, 5109, 9526, 5338];
+  RSRegions.JORMUNGANDS_PRISON         := [0, 5377, 448, 5828];
+  RSRegions.RELLEKKA                   := [5819, 1562, 6441, 2228];
+  RSRegions.UNGAEL                     := [4933, 1622, 5284, 1966];
+  RSRegions.EVIL_CHICKEN_LAIR          := [10156, 4116, 10553, 4494];
+  RSRegions.FEROX_ENCLAVE              := [7803, 1782, 8097, 2062];
+  RSRegions.FOUNTAIN_OF_RUNE           := [8364, 624, 9062, 1575];
+
+  RSNamedRegionsArray := [
+    ['Abyss', RSRegions.ABYSS],
+    ['Altars', RSRegions.ALTARS],
+    ['Al Kharid', RSRegions.AL_KHARID],
+    ['Ardougne', RSRegions.ARDOUGNE],
+    ['Asgarnian Ice Dungeon', RSRegions.ASGARNIAN_ICE_DUNGEON],
+    ['Barbarian Agility Course', RSRegions.BARBARIAN_AGILITY_COURSE],
+    ['Barbarian Village', RSRegions.BARBARIAN_VILLAGE],
+    ['Blast Furnace', RSRegions.BLAST_FURNACE],
+    ['Brimhaven Dungeon', RSRegions.BRIMHAVEN_DUNGEON],
+    ['Castle Wars', RSRegions.CASTLE_WARS],
+    ['Catacombs of Kourend', RSRegions.CATACOMBS_OF_KOUREND],
+    ['Catherby', RSRegions.CATHERBY],
+    ['Chasm of Fire', RSRegions.CHASM_OF_FIRE],
+    ['Corsair Cove', RSRegions.CORSAIR_COVE],
+    ['Corsair Cove Dungeon', RSRegions.CORSAIR_COVE_DUNGEON],
+    ['Crafting Guild', RSRegions.CRAFTING_GUILD],
+    ['Crafting Guild Upstairs', RSRegions.CRAFTING_GUILD_UPSTAIRS],
+    ['Draynor Village', RSRegions.DRAYNOR_VILLAGE],
+    ['Edgeville', RSRegions.EDGEVILLE],
+    ['Falador', RSRegions.FALADOR],
+    ['Fremmennik Slayer Cave', RSRegions.FREMMENNIK_SLAYER_CAVE],
+    ['Giants'' Den', RSRegions.GIANTS_DEN],
+    ['Giants'' Foundry', RSRegions.GIANTS_FOUNDRY],
+    ['Grand Exchange', RSRegions.GRAND_EXCHANGE],
+    ['Guardians of the Rift', RSRegions.GUARDIANS_OF_THE_RIFT],
+    ['Ruins of Unkah', RSRegions.RUINS_OF_UNKAH],
+    ['Shilo Village', RSRegions.SHILO_VILLAGE],
+    ['Fossil Island', RSRegions.FOSSIL_ISLAND],
+    ['Pest Control Island', RSRegions.PEST_CONTROL_ISLAND],
+    ['Pest Control Outpost', RSRegions.PEST_CONTROL_OUTPOST],
+    ['Crandor', RSRegions.CRANDOR],
+    ['Entrana', RSRegions.ENTRANA],
+    ['Hespori', RSRegions.HESPORI],
+    ['Hosidius Fruit Stall House', RSRegions.HOSIDIUS_FRUIT_STALL_HOUSE],
+    ['Hosidius Kitchen', RSRegions.HOSIDIUS_KITCHEN],
+    ['Iorwerth Dungeon', RSRegions.IORWERTH_DUNGEON],
+    ['Kalphite Cave', RSRegions.KALPHITE_CAVE],
+    ['Kalphite Lair', RSRegions.KALPHITE_LAIR],
+    ['Karuulm Slayer Dungeon', RSRegions.KARUULM_SLAYER_DUNGEON],
+    ['KBD and NMZ', RSRegions.KBD_AND_NMZ],
+    ['Kourend Runecrafting', RSRegions.KOUREND_RUNECRAFTING],
+    ['Kraken Cove', RSRegions.KRAKEN_COVE],
+    ['Lumbridge', RSRegions.LUMBRIDGE],
+    ['Lumbridge Cellar', RSRegions.LUMBRIDGE_CELLAR],
+    ['Lumbridge Mid Floor', RSRegions.LUMBRIDGE_MID_FLOOR],
+    ['Lumbridge Roof', RSRegions.LUMBRIDGE_ROOF],
+    ['Lunar Isle', RSRegions.LUNAR_ISLE],
+    ['Mining Guild', RSRegions.MINING_GUILD],
+    ['Mos Le''Harmless Cave', RSRegions.MOS_LEHARMLESS_CAVE],
+    ['Motherloade Mine', RSRegions.MOTHERLOADE_MINE],
+    ['Mourner Tunnels', RSRegions.MOURNER_TUNNELS],
+    ['Musa Point', RSRegions.MUSA_POINT],
+    ['Myths'' Guild Mid Floor', RSRegions.MYTHS_GUILD_MID_FLOOR],
+    ['Otto''s Grotto', RSRegions.OTTOS_GROTTO],
+    ['Piscarilius', RSRegions.PISCARILIUS],
+    ['Piscatoris', RSRegions.PISCATORIS],
+    ['Prifddinas', RSRegions.PRIFDDINAS],
+    ['Rimmington', RSRegions.RIMMINGTON],
+    ['Rogues'' Den', RSRegions.ROGUES_DEN],
+    ['Seers'' Village', RSRegions.SEERS_VILLAGE],
+    ['Slayer Tower Floors', RSRegions.SLAYER_TOWER_FLOORS],
+    ['Slayer Tower Groundfloor', RSRegions.SLAYER_TOWER_GROUNDFLOOR],
+    ['Smoke Devil Dungeon', RSRegions.SMOKE_DEVIL_DUNGEON],
+    ['Smoke Dungeon', RSRegions.SMOKE_DUNGEON],
+    ['Stronghold Slayer Cave', RSRegions.STRONGHOLD_SLAYER_CAVE],
+    ['Tithe farm', RSRegions.TITHE_FARM],
+    ['Mor Ul Rek', RSRegions.MOR_UL_REK],
+    ['Varrock', RSRegions.VARROCK],
+    ['Varrock East', RSRegions.VARROCK_EAST],
+    ['Varrock West', RSRegions.VARROCK_WEST],
+    ['Wintertodt', RSRegions.WINTERTODT],
+    ['Woodcutting Guild', RSRegions.WOODCUTTING_GUILD],
+    ['Yanille', RSRegions.YANILLE],
+    ['Zul-Andra', RSRegions.ZULANDRA],
+    ['POH', RSRegions.POH],
+    ['Tempoross Cove', RSRegions.TEMPOROSS_COVE],
+    ['Zanaris', RSRegions.ZANARIS],
+    ['Varrock Sewers', RSRegions.VARROCK_SEWERS],
+    ['Fossil Island Underwater', RSRegions.FOSSIL_ISLAND_UNDERWATER],
+    ['Keldagrim', RSRegions.KELDAGRIM],
+    ['Port Khazard', RSRegions.PORT_KHAZARD],
+    ['Ape Atoll', RSRegions.APE_ATOLL],
+    ['Miscellania', RSRegions.MISCELLANIA],
+    ['Bandit Camp Quarry', RSRegions.BANDIT_CAMP_QUARRY],
+    ['Tutorial Island', RSRegions.TUTORIAL_ISLAND],
+    ['Death Plateau', RSRegions.DEATH_PLATEAU],
+    ['Clan Hall', RSRegions.CLAN_HALL],
+    ['Redwood', RSRegions.REDWOOD],
+    ['God Wars Dungeon', RSRegions.GOD_WARS_DUNGEON],
+    ['Darkmeyer', RSRegions.DARKMEYER],
+    ['Giants Plateau', RSRegions.GIANTS_PLATEAU],
+    ['Sophanem Bank', RSRegions.SOPHANEM_BANK],
+    ['Gem Rocks Mine', RSRegions.GEM_ROCKS_MINE],
+    ['Isle of Souls', RSRegions.ISLE_OF_SOULS],
+    ['Taverly Dungeon', RSRegions.TAVERLY_DUNGEON],
+    ['Pyramid Plunder', RSRegions.PYRAMID_PLUNDER],
+    ['Sophanem', RSRegions.SOPHANEM],
+    ['Nardah', RSRegions.NARDAH],
+    ['Pyramid Plunder Entrance', RSRegions.PYRAMID_PLUNDER_ENTRANCE],
+    ['Jormungand''s Prison', RSRegions.JORMUNGANDS_PRISON],
+    ['Rellekka', RSRegions.RELLEKKA],
+    ['Ungael', RSRegions.UNGAEL],
+    ['Evil Chicken Lair', RSRegions.EVIL_CHICKEN_LAIR],
+    ['Ferox Enclave', RSRegions.FEROX_ENCLAVE],
+    ['Fountain of Rune', RSRegions.FOUNTAIN_OF_RUNE]
+  ];
+
+  RSBankRegions.Setup();
+end;


### PR DESCRIPTION
Extended map south to allow for teleportation from level 30. The walker was getting lost, by 100s of tiles, right before the level 30 threshold to teleport.

