### PR TITLE
Update Fossil Island bank chest uptext to uppercase C

### DIFF
--- a/osr/walker/objects/rsobjects.simba
+++ b/osr/walker/objects/rsobjects.simba
@@ -359,7 +359,7 @@ begin
   with Self.BankChestFossilIsland do
   begin
     Setup(4, [[9486, 703], [9366, 1075]]);
-    SetupUpText(['Bank c', 'k chest']);
+    SetupUpText(['Bank C', 'k Chest']);
     Finder.Colors += CTS2(1449290, 9, 0.28, 5.71);
     Finder.Colors += CTS2(529505, 11, 0.22, 1.47);
     Finder.Colors += CTS2(5335150, 23, 0.16, 0.58);


### PR DESCRIPTION
Update uptext so that WalkClick() and WalkSelectOption() function works for Drift Net script