### PR TITLE
Add Colour for Greater Nechyrael in Iorwerth Dungeon

### DIFF
--- a/osr/walker/objects/rsmonsters.simba
+++ b/osr/walker/objects/rsmonsters.simba
@@ -435,7 +435,7 @@ begin
     Finder.Colors += CTS2(8558006, 7, 0.04, 1.09);
     Finder.Colors += CTS2(8949654, 10, 0.28, 0.38);
     UpText += 'echr';
-  end;;
+  end;
 
   with Self.Nechryael do
   begin

--- a/osr/walker/objects/rsmonsters.simba
+++ b/osr/walker/objects/rsmonsters.simba
@@ -433,8 +433,9 @@ begin
     Setup(50, 8, [[476, 2925], [3363, 2823], [3380, 2676]]);
     Setup('Greater Nechryael');
     Finder.Colors += CTS2(8558006, 7, 0.04, 1.09);
+    Finder.Colors += CTS2(8949654, 10, 0.28, 0.38);
     UpText += 'echr';
-  end;
+  end;;
 
   with Self.Nechryael do
   begin


### PR DESCRIPTION
Greater Nechrayeal colours do not match in Iorwerth dungeon as it is darker(?), added the correct colour to the monster.