### PR TITLE
Update portalnexus.simba

### DIFF
--- a/optional/interfaces/mainscreen/portalnexus.simba
+++ b/optional/interfaces/mainscreen/portalnexus.simba
@@ -151,7 +151,7 @@ Example:
 *)
 function TRSPortalNexus.FindDestinations(out boxes: TBoxArray; scroll: Int32): TStringArray; overload;
 const
-  COLORS := [2004990, 1803744, 14737632, 16711422];
+  COLORS: TIntegerArray := [2004990, 1803744, 14737632, 16711422];
 var
   tpa: TPointArray;
   atpa: T2DPointArray;


### PR DESCRIPTION
COLORS was missing type declaration, causing GDB to throw error. 

```
Don't know which overloaded method to call with params (array [0..3] of Int64) at line 176, column 51 in file "portalnexus.simba" at line 176, column 58 in file "portalnexus.simba"
Closing XDisplay for thread 140436553332288
[FORMS.PP] ExceptionOccurred 
  Sender=EAccessViolation
  Exception=Access violation
  Stack trace:
  $00007FB9EE4EE6D0
[FORMS.PP] ExceptionOccurred 
ERROR in code: 
Creating gdb catchable error:

  $00000000005AB608
  $00000000005A8905
  $00000000005AC531
  $00000000004FEAE6
  $00000000004FFF24
  $000000000042307B
  $000000000046C9CF
  $000000000042307B
  $0000000000473D5C
  $0000000000426367
[FORMS.PP] ExceptionOccurred 
An unhandled exception occurred at $00000000004B9E20:
EAccessViolation: 
  $00000000004B9E20
  $000000000045C6C6
  $000000000045B8B9
  $0000000000426367
  $00000000004241E1
  $00000000004241E1

double free or corruption (out)  
```