### PR TITLE
Update walker.simba

### DIFF
--- a/osr/walker/walker.simba
+++ b/osr/walker/walker.simba
@@ -1039,6 +1039,7 @@ var
 begin
   angle := Minimap.GetCompassAngle(False);
   tmpArray := Copy(locArray);
+  SetLength(heightArray, Length(tmpArray));          
 
   if not RSHeightMap.Disabled then
     meHeight := Self.GetHeight(me);


### PR DESCRIPTION
Line 1042 TRSWalker.GetCuboidArrayMS was missing a SetLength for an array. It is always out of bounds if you try to use this function. This fixes this. - Club XJ