### PR TITLE
fix: basebankscript withdraw was broken for items with stackcount 1

### DIFF
--- a/osr/basescript.simba
+++ b/osr/basescript.simba
@@ -675,7 +675,7 @@ begin
 
     if Bank.FindItem(item, b) then
     begin
-      if Bank.CountItemStack(item.Item) < item.Quantity then
+      if Max(1,Bank.CountItemStack(item.Item)) < item.Quantity then
       begin
         Self.BankEmpty := Bank.IsOpen();
         if Self.BankEmpty then


### PR DESCRIPTION
can now withdraw if quantity is one and item has only one in bank