### PR TITLE
fix: foolproofed hoplist 

### DIFF
--- a/osr/interfaces/gametabs/worldhopper.simba
+++ b/osr/interfaces/gametabs/worldhopper.simba
@@ -331,6 +331,7 @@ begin
   until GetSystemTime() > timeOut;
 
   Self.DebugLn("Timed out (timeOut="+ToStr(timeOut)+"ms)");
+  targetWorlds.Remove(nextWorld);
 end;
 
 var


### PR DESCRIPTION
Makes it so that inaccessible or non-existing worlds are not being hopped to