### PR TITLE
Removed ERSConsumable.Venom and venomhandler

### DIFF
--- a/osr/handlers/consumablehandler.simba
+++ b/osr/handlers/consumablehandler.simba
@@ -68,7 +68,6 @@ begin
     ERSConsumable.PRAYER:    Result.SetupPrayer();
     ERSConsumable.ENERGY:    Result.SetupEnergy();
     ERSConsumable.POISON:    Result.SetupAntiPoison();
-    ERSConsumable.VENOM:     Result.SetupAntiVenom();
     ERSConsumable.ANTI_FIRE: Result.SetupAntiFire();
     else Result.SetupBoost();
   end;
@@ -163,7 +162,6 @@ begin
     ERSConsumable.PRAYER:         Self.Name := 'PrayerHandler';
     ERSConsumable.ENERGY:         Self.Name := 'EnergyHandler';
     ERSConsumable.POISON:         Self.Name := 'PoisonHandler';
-    ERSConsumable.VENOM:          Self.Name := 'VenomHandler';
     ERSConsumable.ANTI_FIRE:      Self.Name := 'AntiFireHandler';
     ERSConsumable.BOOST:          Self.Name := 'BoostHandler';
     ERSConsumable.STRENGTH_BOOST: Self.Name := 'StrengthBoostHandler';
@@ -193,7 +191,6 @@ FoodHandler:          TConsumableHandler;
 PrayerHandler:        TConsumableHandler;
 EnergyHandler:        TConsumableHandler;
 PoisonHandler:        TConsumableHandler;
-VenomHandler:         TConsumableHandler;
 AntifireHandler:      TConsumableHandler;
 BoostHandler:         TConsumableHandler;
 StrengthBoostHandler: TConsumableHandler;
@@ -203,7 +200,7 @@ RangingBoostHandler:  TConsumableHandler;
 MagicBoostHandler:    TConsumableHandler;
 
 CONSUMABLE_HANDLER_ARRAY: array [ERSConsumable] of PConsumableHandler := [
-  @FoodHandler, @PrayerHandler, @EnergyHandler, @PoisonHandler, @VenomHandler,
+  @FoodHandler, @PrayerHandler, @EnergyHandler, @PoisonHandler,
   @AntifireHandler, @BoostHandler, @StrengthBoostHandler, @AttackBoostHandler,
   @DefenceBoostHandler, @RangingBoostHandler, @MagicBoostHandler
 ];
@@ -215,7 +212,6 @@ Global handler variables. This handlers are the ones responsible for handling co
   PrayerHandler:        TConsumableHandler;
   EnergyHandler:        TConsumableHandler;
   PoisonHandler:        TConsumableHandler;
-  VenomHandler:         TConsumableHandler;
   AntifireHandler:      TConsumableHandler;
   BoostHandler:         TConsumableHandler;
   StrengthBoostHandler: TConsumableHandler;
@@ -225,7 +221,7 @@ Global handler variables. This handlers are the ones responsible for handling co
   MagicBoostHandler:    TConsumableHandler;
 
   CONSUMABLE_HANDLER_ARRAY: array [ERSConsumable] of PConsumableHandler := [
-    @FoodHandler, @PrayerHandler, @EnergyHandler, @PoisonHandler, @VenomHandler,
+    @FoodHandler, @PrayerHandler, @EnergyHandler, @PoisonHandler,
     @AntifireHandler, @BoostHandler, @StrengthBoostHandler, @AttackBoostHandler,
     @DefenceBoostHandler, @RangingBoostHandler, @MagicBoostHandler
   ];
@@ -340,10 +336,11 @@ Inventory.Consume(ERSConsumable.FOOD);
 *)
 function TRSInventory.Consume(consumableType: ERSConsumable; out slots: TIntegerArray): Boolean;
 var
-  consumableHandler, tmp: PConsumableHandler;
+  consumableHandler: PConsumableHandler;
   foundConsumables: TRSConsumableArray;
   startingPoints: Int32;
   trashSlots: TIntegerArray;
+  slotBox: TBox;
 begin
   consumableHandler := TConsumableHandler.GetHandler(consumableType);
   if not consumableHandler^.IsSetup then
@@ -352,16 +349,13 @@ begin
   case consumableType of
     ERSConsumable.FOOD:
       startingPoints := Minimap.GetHPLevel();
-
     ERSConsumable.PRAYER:
       startingPoints := Minimap.GetPrayerLevel();
-
     ERSConsumable.ENERGY:
       startingPoints := Minimap.GetRunEnergy();
   end;
 
   slots := Self.FindConsumable(consumableType, foundConsumables);
-
   if slots.Len() = 0 then
     Exit;
 
@@ -372,37 +366,23 @@ begin
   if (consumableHandler^.Delay.Length > 0) then
     while not consumableHandler^.Delay.IsFinished() do
       Wait(50, 100);
-
+  slotBox := Self.GetSlotBox(slots[0]);
   Result := Self.ClickSlot(slots[0], ['Eat', 'Drink']);
-
-  if Result then
-    case consumableType of
-      ERSConsumable.FOOD:
-        Result := WaitUntil(startingPoints < Minimap.GetHPLevel(), 100, 3000);
-
-      ERSConsumable.PRAYER:
-        Result := WaitUntil(startingPoints < Minimap.GetPrayerLevel(), 100, 3000);
-
-      ERSConsumable.ENERGY:
-        Result := WaitUntil(startingPoints < Minimap.GetRunEnergy(), 100, 3000);
-      else
-        Antiban.BioWait(1000, 2000, wdLeft);
-    end;
 
   if Result then
   begin
     case consumableType of
       ERSConsumable.FOOD:
-        begin
-          if foundConsumables[0].Item = 'Cooked karambwan' then
-            consumableHandler^.Delay.Init(1200)
-          else
-            consumableHandler^.Delay.Init(1800);
-        end;
+        Result := WaitUntil(startingPoints < Minimap.GetHPLevel(), 100, 3000);
+      ERSConsumable.PRAYER:
+        Result := WaitUntil(startingPoints < Minimap.GetPrayerLevel(), 100, 3000);
+      ERSConsumable.ENERGY:
+        Result := WaitUntil(startingPoints < Minimap.GetRunEnergy(), 100, 3000);
       else
-        for tmp in CONSUMABLE_HANDLER_ARRAY do
-            tmp^.Delay.Init(600);
+        Result := (SRL.PercentShift(slotBox, 150) >= 25);
     end;
+
+    consumableHandler^.Delay.Init(foundConsumables[0].Timer);
 
     if foundConsumables[0].Timer > 0 then
     begin
@@ -423,8 +403,7 @@ begin
         Bank.DepositSlot([trashSlots[0], -1], False)
       else
         Self.ShiftDrop(trashSlots.Intersection(Self.RandomPattern()));
-
-      slots := slots.Difference(trashSlots); //Delete trashSlots from slots.
+      slots := slots.Difference(trashSlots);
     end;
   end;
 end;
@@ -791,4 +770,3 @@ begin
   if combobox <> nil then
     combobox.SetOnChange(event);
 end;
-

--- a/utils/items/consumables.simba
+++ b/utils/items/consumables.simba
@@ -15,7 +15,6 @@ ERSConsumable = (
   FOOD,
   PRAYER,
   POISON,
-  VENOM,
   ANTI_FIRE,
   STRENGTH_BOOST,
   ATTACK_BOOST,
@@ -29,7 +28,7 @@ ERSConsumable = (
 
 ERSConsumable is a enumerator that contains all types of consumable.
 *)
-  ERSConsumable = (FOOD, PRAYER, ENERGY, POISON, VENOM, ANTI_FIRE, BOOST, STRENGTH_BOOST, ATTACK_BOOST, DEFENCE_BOOST, RANGING_BOOST, MAGIC_BOOST);
+  ERSConsumable = (FOOD, PRAYER, ENERGY, POISON, ANTI_FIRE, BOOST, STRENGTH_BOOST, ATTACK_BOOST, DEFENCE_BOOST, RANGING_BOOST, MAGIC_BOOST);
 
 var
 (*
@@ -39,8 +38,7 @@ var
   FOOD_ARRAY: TRSItemArray = ['Shrimps', 'Cooked chicken', 'Cooked meat', 'Sardine', 'Bread', 'Herring', 'Mackerel', 'Choc-ice', 'Trout', 'Cod', 'Pike', 'Roast beast meat', 'Pineapple punch', 'Salmon', 'Tuna', 'Jug of wine', 'Rainbow fish', 'Stew', 'Banana stew', 'Cake(1..3)', 'Meat pie(1..2)', 'Bass', 'Plain pizza(1..2)', 'Lobster', 'Swordfish', 'Potato with butter', 'Apple pie(1..2)', 'Chocolate cake(1..3)', 'Tangled toad' 's legs', 'Chocolate bomb', 'Potato with cheese', 'Meat pizza(1..2)', 'Admiral pie(1..2)', 'Monkfish', 'Anchovy pizza(1..2)', 'Cooked karambwan', 'Curry', 'Ugthanki kebab', 'Guthix rest(1..4)', 'Dragonfruit pie(1..2)', 'Mushroom potato', 'Shark', 'Sea turtle', 'Pineapple pizza(1..2)', 'Summer pie(1..2)', 'Wild pie(1..2)', 'Manta ray', 'Tuna potato', 'Dark crab', 'Anglerfish', 'Saradomin brew(1..4)'];
   PRAYER_ARRAY: TRSItemArray = ['Zamorak brew(1..4)', 'Sanfew serum(1..4)', 'Super restore(1..4)', 'Prayer potion(1..4)', 'Jangerberries'];
   ENERGY_ARRAY: TRSItemArray = ['White tree fruit', 'Winter sq' 'irkjuice', 'Spring sq' 'irkjuice', 'Autumn sq' 'irkjuice', 'Summer sq' 'irkjuice', 'Bandages', 'Guthix rest(1..4)', 'Papaya fruit', 'Energy potion(1..4)', 'Purple sweets', 'Summer pie(1..2)', 'Super energy(1..4)', 'Stamina potion(1..4)', 'Strange fruit', 'Mint cake', 'Gout tuber'];
-  ANTI_POISON_ARRAY: TRSItemArray = ['Sanfew serum(1..4)', 'Anti-venom+(1..4)', 'Anti-venom(1..4)', 'Antidote++(1..4)', 'Antidote+(1..4)', 'Superantipoison(1..4)', 'Antipoison(1..4)'];
-  ANTI_VENOM_ARRAY: TRSItemArray = ['Anti-venom+(1..4)', 'Anti-venom(1..4)'];
+  ANTI_POISON_ARRAY: TRSItemArray = ['Sanfew serum(1..4)', 'Anti-venom+(1..4)', 'Anti-venom(1..4)', 'Antidote++(1..4)', 'Antidote+(1..4)', 'Superantipoison(1..4)', 'Antipoison(1..4)',  'Extended anti-venom+(1..4)'];
   ANTI_FIRE_ARRAY: TRSItemArray = ['Antifire potion(1..4)', 'Super antifire potion(1..4)', 'Extended antifire(1..4)', 'Extended super antifire(1..4)'];
   BOOST_ARRAY: TRSItemArray = ['Divine super combat potion(1..4)', 'Super combat potion(1..4)', 'Divine bastion potion(1..4)', 'Bastion potion(1..4)', 'Divine battlemage potion(1..4)', 'Battlemage potion(1..4)'];
   STRENGTH_BOOST_ARRAY: TRSItemArray = ['Divine super strength potion(1..4)', 'Super strength(1..4)', 'Strength potion(1..4)'];
@@ -64,8 +62,7 @@ WriteLn CONSUMABLE_ARRAYS[ERSConsumable.ENERGY];
   FOOD_ARRAY: TRSItemArray = ['Shrimps', 'Cooked chicken', 'Cooked meat', 'Sardine', 'Bread', 'Herring', 'Mackerel', 'Choc-ice', 'Trout', 'Cod', 'Pike', 'Cooked wild kebbit', 'Sunlight moth mix (1..2)', 'Sunlight moth', 'Roast beast meat', 'Pineapple punch', 'Salmon', 'Tuna', 'Jug of wine', 'Rainbow fish', 'Cooked larupia', 'Stew', 'Banana stew', 'Cake(1..3)', 'Meat pie(1..2)', 'Bass', 'Plain pizza(1..2)', 'Lobster', 'Cooked barb-tailed kebbit', 'Swordfish', 'Cooked graahk', 'Potato with butter', 'Apple pie(1..2)', 'Chocolate cake(1..3)', 'Tangled toad' 's legs', 'Chocolate bomb', 'Potato with cheese', 'Egg potato', 'Meat pizza(1..2)', 'Admiral pie(1..2)', 'Monkfish', 'Cooked kyatt', 'Anchovy pizza(1..2)', 'Cooked karambwan', 'Curry', 'Ugthanki kebab', 'Guthix rest(1..4)', 'Dragonfruit pie(1..2)', 'Mushroom potato', 'Shark', 'Cooked pyre fox', 'Sea turtle', 'Cooked sunlight antelope', 'Pineapple pizza(1..2)', 'Summer pie(1..2)', 'Wild pie(1..2)', 'Manta ray', 'Cooked dashing kebbit', 'Tuna potato', 'Dark crab', 'Anglerfish', 'Cooked moonlight antelope', 'Saradomin brew(1..4)', 'Cooked bream'];
   PRAYER_ARRAY: TRSItemArray = ['Zamorak brew(1..4)', 'Sanfew serum(1..4)', 'Super restore(1..4)', 'Prayer potion(1..4)', 'Moonlight moth mix (1..2)', 'Moonlight moth', 'Jangerberries'];
   ENERGY_ARRAY: TRSItemArray = ['White tree fruit', 'Winter sq' 'irkjuice', 'Spring sq' 'irkjuice', 'Autumn sq' 'irkjuice', 'Summer sq' 'irkjuice', 'Bandages', 'Guthix rest(1..4)', 'Papaya fruit', 'Energy potion(1..4)', 'Purple sweets', 'Summer pie(1..2)', 'Super energy(1..4)', 'Stamina potion(1..4)', 'Strange fruit', 'Mint cake', 'Gout tuber'];
-  ANTI_POISON_ARRAY: TRSItemArray = ['Sanfew serum(1..4)', 'Anti-venom+(1..4)', 'Anti-venom(1..4)', 'Antidote++(1..4)', 'Antidote+(1..4)', 'Superantipoison(1..4)', 'Antipoison(1..4)'];
-  ANTI_VENOM_ARRAY: TRSItemArray = ['Anti-venom+(1..4)', 'Anti-venom(1..4)', 'Extended anti-venom+(1..4)'];
+  ANTI_POISON_ARRAY: TRSItemArray = ['Sanfew serum(1..4)', 'Anti-venom+(1..4)', 'Anti-venom(1..4)', 'Antidote++(1..4)', 'Antidote+(1..4)', 'Superantipoison(1..4)', 'Antipoison(1..4)', 'Extended anti-venom+(1..4)'];
   ANTI_FIRE_ARRAY: TRSItemArray = ['Antifire potion(1..4)', 'Super antifire potion(1..4)', 'Extended antifire(1..4)', 'Extended super antifire(1..4)'];
   BOOST_ARRAY: TRSItemArray = ['Divine super combat potion(1..4)', 'Super combat potion(1..4)', 'Divine bastion potion(1..4)', 'Bastion potion(1..4)', 'Divine battlemage potion(1..4)', 'Battlemage potion(1..4)'];
   STRENGTH_BOOST_ARRAY: TRSItemArray = ['Divine super strength potion(1..4)', 'Super strength(1..4)', 'Strength potion(1..4)'];
@@ -75,7 +72,7 @@ WriteLn CONSUMABLE_ARRAYS[ERSConsumable.ENERGY];
   MAGIC_BOOST_ARRAY: TRSItemArray = ['Divine magic potion(1..4)', 'Magic potion(1..4)'];
   TRASH_ARRAY: TRSItemArray = ['Cocktail glass', 'Jug', 'Bowl', 'Pie dish', 'Vial', 'Beer glass', 'Empty cup'];
 
-  CONSUMABLE_ARRAYS: array [ERSConsumable] of TRSItemArray := [FOOD_ARRAY, PRAYER_ARRAY, ENERGY_ARRAY, ANTI_POISON_ARRAY, ANTI_VENOM_ARRAY, ANTI_FIRE_ARRAY, BOOST_ARRAY, STRENGTH_BOOST_ARRAY, ATTACK_BOOST_ARRAY, DEFENCE_BOOST_ARRAY, RANGING_BOOST_ARRAY, MAGIC_BOOST_ARRAY];
+  CONSUMABLE_ARRAYS: array [ERSConsumable] of TRSItemArray := [FOOD_ARRAY, PRAYER_ARRAY, ENERGY_ARRAY, ANTI_POISON_ARRAY, ANTI_FIRE_ARRAY, BOOST_ARRAY, STRENGTH_BOOST_ARRAY, ATTACK_BOOST_ARRAY, DEFENCE_BOOST_ARRAY, RANGING_BOOST_ARRAY, MAGIC_BOOST_ARRAY];
 
 type
 (*
@@ -161,7 +158,6 @@ procedure TRSConsumable.SetupFood();
 procedure TRSConsumable.SetupPrayer();
 procedure TRSConsumable.SetupEnergy();
 procedure TRSConsumable.SetupAntiPoison();
-procedure TRSConsumable.SetupAntiVenom();
 procedure TRSConsumable.SetupAntiFire();
 procedure TRSConsumable.SetupBoost();
 ```
@@ -172,6 +168,14 @@ var
   HPLevel: Int32;
 begin
   if Self.IsSetup then Exit;
+
+  case Self.Item of
+    // Special 2-tick food
+    'Cooked karambwan': Self.Timer := 1200;
+    // Else normal 3-tick food
+    else Self.Timer := 1800;
+  end;
+
   case Self.Item of
     'Shrimps', 'Cooked chicken', 'Cooked meat': Self.Points := 3;
     'Sardine', 'Cake(1..3)', 'Edible seaweed': Self.Points := 4;
@@ -217,6 +221,7 @@ procedure TRSConsumable.SetupPrayer();
 begin
   if Self.IsSetup then
     Exit;
+  Self.Timer := 1800;
   case Self.Item of
     'Prayer potion(1..4)': Self.Points := Floor((Stats.GetLevel(ERSSkill.PRAYER) * 0.25) + 7);
     'Super restore(1..4)': Self.Points := Floor((Stats.GetLevel(ERSSkill.PRAYER) * 0.25) + 8);
@@ -233,6 +238,10 @@ begin
   if Self.IsSetup then
     Exit;
   case Self.Item of
+    'Stamina potion(1..4)': Self.Timer := 2 * ONE_MINUTE;
+    else Self.Timer := 1800;
+  end;
+  case Self.Item of
     'White tree fruit': Self.Points := 5;
     'Winter sq' 'irkjuice': Self.Points := 10;
     'Spring sq' 'irkjuice': Self.Points := 20;
@@ -245,11 +254,7 @@ begin
     'Purple sweets': Self.Points := 10;
     'Summer pie(1..2)': Self.Points := 10;
     'Super energy(1..4)': Self.Points := 20;
-    'Stamina potion(1..4)':
-      begin
-        Self.Points := 20;
-        Self.Timer := 2 * ONE_MINUTE;
-      end;
+    'Stamina potion(1..4)': Self.Points := 20;
     'Strange fruit': Self.Points := 30;
     'Mint cake': Self.Points := 50;
     'Gout tuber': Self.Points := 50;
@@ -261,32 +266,11 @@ procedure TRSConsumable.SetupAntiPoison();
 begin
   if Self.IsSetup then
     Exit;
-  
-  case Self.Item of
-    'Sanfew serum(1..4)': Self.Timer := 6 * ONE_MINUTE;
-    'Anti-venom+(1..4)': Self.Timer := 15 * ONE_MINUTE;
-    'Anti-venom(1..4)': Self.Timer := 12 * ONE_MINUTE;
-    'Antidote++(1..4)': Self.Timer := 12 * ONE_MINUTE;
-    'Antidote+(1..4)': Self.Timer := 9 * ONE_MINUTE;
-    'Superantipoison(1..4)': Self.Timer := 6 * ONE_MINUTE;
-    'Antipoison(1..4)': Self.Timer := 90 * ONE_SECOND;
-  end;
-  Self.Points := 1; 
-  Self._Setup(); 
-end;  
 
-procedure TRSConsumable.SetupAntiVenom();
-begin
-  if Self.IsSetup then
-    Exit;
-
-  case Self.Item of
-    'Anti-venom+(1..4)': Self.Timer := 3 * ONE_MINUTE;
-    'Anti-venom(1..4)': Self.Timer := 18 * ONE_SECOND;
-  end;
-  Self.Points := 1; 
+  Self.Timer := 1800;
+  Self.Points := 1;
   Self._Setup();
-end;  
+end;
 
 procedure TRSConsumable.SetupAntiFire();
 begin


### PR DESCRIPTION
Potions shared between venom handlers and poison handlers could cause double consumption, so it made more sense to remove one of the handlers. 

`TRSInventory.Consume` verification has been added for clicking on potions without visual indicators, like antifire and boosts, instead of an antiban wait.  Food timers have been moved from `TRSInventory.Consume` to `TRSConsumable.SetupFood`. 