### PR TITLE
Biohash fixes to fix the SleepHour invalid time format issues.

### DIFF
--- a/utils/biometrics.simba
+++ b/utils/biometrics.simba
@@ -128,13 +128,14 @@ var
   h, i: UInt32;
   k: String;
 begin
-  BioHash := BioHashOverride;
+  if BioHashOverride <> 0 then
+    BioHash := BioHashOverride;
 
   if BioHash = 0 then
   begin
     if (Length(Login.Players) = 0) or (BioHash <> 0) then
     begin
-      BioHash := Random($FFFFFFFF) * 0.111111111111111;
+      BioHash := Random(0, 1.0);
       DebugLn('Temporary Biohash: ' + ToStr(BioHash));
       Exit;
     end;
@@ -554,4 +555,3 @@ begin
   else
     Mouse.Click(MOUSE_LEFT);
 end;
-

--- a/utils/forms/scriptform.simba
+++ b/utils/forms/scriptform.simba
@@ -1257,6 +1257,7 @@ begin
     SetMin(0);
     SetMax(9);
     setAlign(alBottom);
+    setPosition(Round(BioHash * bar.getMax()));
     SetTooltip('You can adjust your biohash with this trackbar, however, the default is recommended.');
     setOnChange(@Self._BarOnChange);
   end;


### PR DESCRIPTION
- Temorary Biohash created 1 time now.
- Fixed the biohash generation because it could be a stupid large number which could corrupt the Sleep Hour.
- Adjusted scriptform biohash setting because SetOnChange is called and with a Temporary Biohash it could change the value of it.