### PR TITLE
add a safety check for the wyvern caves

### DIFF
--- a/optional/handlers/birdhousehandler.simba
+++ b/optional/handlers/birdhousehandler.simba
@@ -65,7 +65,7 @@ type
     USE_PENDANT,
 
     NEXT_LOCATION,
-
+    EXIT_CAVE,
     USE_MUSHTREE,
 
     UPDATE_BIRDHOUSE,
@@ -86,6 +86,8 @@ type
   TBirdHouseHandler = record(TSRLBaseRecord)
     State: EBirdHouseHandlerState;
 
+
+    WyvernCaveLadder: TRSObjectV2;
     Location: EBirdHouseLocation;
     Houses: array [EBirdHouseLocation] of TBirdHouse;
     Wood: EBirdHouseWood;
@@ -180,6 +182,7 @@ var
   bounds: TBox;
   sizeMap, sizeBMP, sizeNew: TPoint;
 begin
+  // wyvern cave in fossil island: Chunk([55,161,57,159], 0)
   Self.Map.Loader.Load([Chunk([56,61,60,57], 0), Chunk([58,60,58,60], 1)], 8, 80);
 
   //add map to our handler map regardless of where it came from, TRSMap or TRSWalker
@@ -275,6 +278,19 @@ begin
     Result := WaitUntil(Self.Map.GetRegionIndex() = 1, 300, 5000);
 end;
 
+function TBirdHouseHandler.IsInWyvernCave(): Boolean;
+begin
+  // or pointinpoly/box
+  Result := Self.Map.GetRegionIndex() = 123;
+end;
+
+function TBirdHouseHandler.ExitWyvernCave(): Boolean;
+begin
+  if Self.IsInWyvernCave() then
+    Self.WyvernCaveLadder.WalkClick();
+
+  Result := WaitUntil(not Self.IsInWyvernCave(), 750, 7500);
+end;
 
 function TBirdHouseHandler.InLocation(): Boolean;
 begin
@@ -422,6 +438,8 @@ begin
       EBirdHouseHandlerState.CRAFT_BIRDHOUSE: Self.CraftHouse();
       EBirdHouseHandlerState.BUILD_BIRDHOUSE: Self.BuildHouse();
       EBirdHouseHandlerState.FILL_BIRDHOUSE: Self.FillHouse();
+
+      EBirdHouseHandlerState.EXIT_CAVE: Self.ExitWyvernCave();
 
       EBirdHouseHandlerState.FINISH: Break;
     end;


### PR DESCRIPTION
There is a [trapdoor](https://oldschool.runescape.wiki/w/Wyvern_Cave#Northern_cave) right in the center of fossil island and the runner _will_ occasionally missclick it and enter the caves. 

Would be a good idea to add functionality to exit the caves.