### PR TITLE
fix: rsfishinghandler spot move checks correct position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 CHANGELOG.md
 overrides.simba
 osr/walker/maps/*
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bug Fixes
 
 * update gear.json ([43eb5b2](https://github.com/Torwent/WaspLib/commit/43eb5b2fe16f52ac1dbaec640bc3e3689eeee7b4))
+* rsfishinghandler: fix SpotMove check ([78bff0e](https://github.com/Torwent/WaspLib/pull/238/commits/78bff0e62aaf63a0c2afdb7cda3f538f5198ff00))
 
 
 

--- a/optional/handlers/rsfishinghandler.simba
+++ b/optional/handlers/rsfishinghandler.simba
@@ -481,7 +481,8 @@ begin
   begin
     for tpa in atpa do
     begin
-      Result := Self.CurrentSpot.InRange(MainScreen.PointToMM(tpa.Mean(), 0).ToPoint(), 6);
+      currentPosition := ScriptWalker^.MSToWorld(tpa.Mean(), 0);
+      Result := Self.CurrentSpot.InRange(currentPosition, 6);
       if Result then
         Break;
     end;


### PR DESCRIPTION
Uses the same logic that sets `Self.CurrentSpot` to also check if the previously set `Self.CurrentSpot` is in range.