### PR TITLE
Bugfix: fix TRSFishingHandle.SpotMove's current location check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 CHANGELOG.md
 overrides.simba
 osr/walker/maps/*
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 ### Bug Fixes
 
 * update gear.json ([43eb5b2](https://github.com/Torwent/WaspLib/commit/43eb5b2fe16f52ac1dbaec640bc3e3689eeee7b4))
-* rsfishinghandler: fix TRSFishingHandler.SpotMove check ([78bff0e](https://github.com/Torwent/WaspLib/pull/238/commits/78bff0e62aaf63a0c2afdb7cda3f538f5198ff00))
-
+* rsfishinghandler: fix TRSFishingHandler.SpotMove check])
 
 ## [20.3.2](https://github.com/Torwent/WaspLib/compare/v20.3.1...v20.3.2) (2025-05-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Bug Fixes
 
 * update gear.json ([43eb5b2](https://github.com/Torwent/WaspLib/commit/43eb5b2fe16f52ac1dbaec640bc3e3689eeee7b4))
-
+* rsfishinghandler: fix TRSFishingHandler.SpotMove check ([78bff0e](https://github.com/Torwent/WaspLib/pull/238/commits/78bff0e62aaf63a0c2afdb7cda3f538f5198ff00))
 
 
 ## [20.3.2](https://github.com/Torwent/WaspLib/compare/v20.3.1...v20.3.2) (2025-05-29)

--- a/optional/handlers/rsfishinghandler.simba
+++ b/optional/handlers/rsfishinghandler.simba
@@ -481,7 +481,8 @@ begin
   begin
     for tpa in atpa do
     begin
-      Result := Self.CurrentSpot.InRange(MainScreen.PointToMM(tpa.Mean(), 0).ToPoint(), 6);
+      currentPosition := ScriptWalker^.MSToWorld(tpa.Mean(), 0);
+      Result := Self.CurrentSpot.InRange(currentPosition, 6);
       if Result then
         Break;
     end;


### PR DESCRIPTION
Use the same function to create a new "current" position `TPoint` as is used for setting `Self.CurrentSpot`.