### PR TITLE
Add Arkan blade to combat handler and weapon data

### DIFF
--- a/optional/handlers/combathandler.simba
+++ b/optional/handlers/combathandler.simba
@@ -30,7 +30,8 @@ const
     'Venator bow', 'Dragon crossbow', 'Rune crossbow', 'Adamant dart',
     'Mithril dart', 'Rune scimitar', 'Dorgeshuun crossbow',
     'Leaf-bladed sword', 'Leaf-bladed battleaxe', 'Zombie axe', 
-	  'Osmumten''s fang', 'Noxious halberd', 'Dual macuahuitl', 'Null'
+	'Osmumten''s fang', 'Noxious halberd', 'Dual macuahuitl', 
+	'Arkan blade', 'Null'
   ];
 
   SHIELDS: TRSItemArray = [
@@ -49,7 +50,7 @@ const
     'Dragon sword', 'Dragon longsword', 'Dinh''s bulwark', 'Abyssal tentacle',
     'Saradomin godsword', 'Granite hammer', 'Toxic blowpipe', 'Magic shortbow',
     'Magic shortbow (i)', 'Armadyl crossbow', 'Dragon crossbow', 'Dragon thrownaxe',
-    'Osmumten''s fang', 'Null'
+    'Osmumten''s fang', 'Arkan blade', 'Null'
   ];
 
   BRACELETS: TRSItemArray = [

--- a/utils/data/weapons.json
+++ b/utils/data/weapons.json
@@ -910,5 +910,21 @@
       "hitpoints": 0,
       "prayer": 0
     }
+  },
+  "Arkan blade": {
+    "type": "melee",
+    "speed": 4,
+    "range": 1,
+    "two-handed": false,
+    "special_attack": 30,
+    "level_requirements": {
+      "attack": 60,
+      "strength": 0,
+      "ranged": 0,
+      "magic": 0,
+      "defence": 0,
+      "hitpoints": 0,
+      "prayer": 0
+    }
   }
 }


### PR DESCRIPTION
Addition of Arkan Blade to WaspScripts database so it can be pulled using the CombatHandler for a Spec or Attack weapon.